### PR TITLE
Fix typos in JLQNModel validation

### DIFF
--- a/src/main/java/jlqn/model/JLQNModel.java
+++ b/src/main/java/jlqn/model/JLQNModel.java
@@ -1722,8 +1722,7 @@ public class JLQNModel implements JLQNConstants {
     }
     public boolean setEntryPriority(int[] entryPriority) {
         if (entryPriority.length != numberOfEntries) {
-
-            throw new IllegalArgumentException("entryArrivalRate.length!=numberOfEntries");
+            throw new IllegalArgumentException("entryPriority.length!=numberOfEntries");
         }
 
 
@@ -1883,7 +1882,7 @@ public class JLQNModel implements JLQNConstants {
 
     public boolean setPrecedencePostActivities(String[][] precedencePostActivities) {
         if (precedencePostActivities.length != numberOfPrecedences) {
-            throw new IllegalArgumentException("precedencePostActitivies.length!=numberOfPrecedences");
+            throw new IllegalArgumentException("precedencePostActivities.length!=numberOfPrecedences");
         }
         boolean changesPresent = false;
         if (this.precedencePostActivities.length == precedencePostActivities.length) {


### PR DESCRIPTION
## Summary
- fix incorrect exception message in `setEntryPriority`
- fix typo in `setPrecedencePostActivities` validation

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68412646a898832f9780f70782bbbba2